### PR TITLE
ROM_Builders: Add Support to push DL Link to TG Channel [skip ci]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -169,6 +169,7 @@ task:
     - device=$(grep unch $CIRRUS_WORKING_DIR/build_rom.sh -m 1 | cut -d ' ' -f 2 | cut -d _ -f 2 | cut -d - -f 1)
     - grep _jasmine_sprout $CIRRUS_WORKING_DIR/build_rom.sh > /dev/null && device=jasmine_sprout
     - your_telegram_id=@ROM_builders_channel
-    - curl -s "https://api.telegram.org/bot${bot_api}/sendmessage" -d "text=<code>$device-$rom_name</code> Succeed
+    - curl -s "https://api.telegram.org/bot${bot_api}/sendmessage" -d "text=<code>$device-$rom_name</code> Succeeded
       
-      https://cirrus-ci.com/build/$CIRRUS_BUILD_ID" -d "chat_id=${your_telegram_id}" -d "parse_mode=HTML"
+      <code>Build Link</code> https://cirrus-ci.com/build/$CIRRUS_BUILD_ID" -d "chat_id=${your_telegram_id}" -d "parse_mode=HTML"
+


### PR DESCRIPTION
* Pushing DL Links to TG Will help users when cirrus websites sometimes crashes , or sometimes takes time to load, users can take a look at logs using Build URL & Download Build using Download URL, This implementation should work in one go, but i do suggest to test it on a build if it does work, also alliterate build succeed to Build Succeeded.

Change-Id: I8c038051ada35d1a0ad7a3d6d2bbfd9ce6ff5f49
Signed-off-by: techyminati <techyminati@cipheros.site>