### PR TITLE
add support uploading retrofit zips [skip ci]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -203,8 +203,8 @@ task:
     - grep _laurel_sprout $CIRRUS_WORKING_DIR/build_rom.sh > /dev/null && device=laurel_sprout
     - grep _maple_dsds $CIRRUS_WORKING_DIR/build_rom.sh > /dev/null && device=maple_dsds
     - cd ~/roms/$rom_name
-    - engzip=$(ls out/target/product/$device/*-eng*.zip || true)
-    - otazip=$(ls out/target/product/$device/*-ota-*.zip | grep -v "hentai" | grep -v "evolution" || true)
+    - engzip=$(ls out/target/product/$device/*-eng*.zip | grep -v "retrofit" || true)
+    - otazip=$(ls out/target/product/$device/*-ota-*.zip | grep -v "hentai" | grep -v "evolution" | grep -v "retrofit" || true)
     - awaken=$(ls out/target/product/$device/Project-Awaken*.zip || true)
     - octavi=$(ls out/target/product/$device/OctaviOS-R*.zip || true)
     - p404=$(ls out/target/product/$device/?.*zip || true)


### PR DESCRIPTION
For eg: aosp_chef-ota-retrofit-eng.cirrus.zip made by mka otapackage command gets deleted due to wildcard entry ota.
Hence the build fails at run upload rom stage as no zip is found

Required for [chef] , maybe also for other devices :)

https://cirrus-ci.com/task/6668806268387328