### PR TITLE
ci: Add a script to remove kernels that leave KSU fragments [skip ci]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,6 +45,7 @@ task:
           - /home/cirrus/.config:/home/cirrus/.config
   show_script: cat $CIRRUS_WORKING_DIR/build_rom.sh
   test_script: curl -s https://raw.githubusercontent.com/ROM-builders/temporary/main/ci/test.sh | bash
+  clean_kernels_script: curl -s https://raw.githubusercontent.com/ROM-builders/temporary/main/ci/clean_dirty_kernels.sh | bash
   sync_script: curl -s https://raw.githubusercontent.com/ROM-builders/temporary/main/ci/sync.sh | bash
   tsync_script: curl -s https://raw.githubusercontent.com/ROM-builders/temporary/main/ci/tsync.sh | bash
   build_script: curl -s https://raw.githubusercontent.com/ROM-builders/temporary/main/ci/build.sh | bash

--- a/ci/clean_dirty_kernels.sh
+++ b/ci/clean_dirty_kernels.sh
@@ -7,8 +7,8 @@ BASE_DIR="kernel"
 remove_subdirs_if_kernelsu() {
   local dir="$1"
 
-  # Check if KernelSU directory exists at any level in the given folder
-  if find "$dir" -type d -name "KernelSU" | grep -q .; then
+  # Check if KernelSU directory exists at any level in the given folder (case-insensitive)
+  if find "$dir" -type d -iname "KernelSU" | grep -q .; then
     echo "Removing subdirectories of $dir because KernelSU directory is present."
     find "$dir" -mindepth 1 -maxdepth 1 -type d -exec rm -rf -v {} \;
   fi

--- a/ci/clean_dirty_kernels.sh
+++ b/ci/clean_dirty_kernels.sh
@@ -1,21 +1,25 @@
+#!/bin/bash
+
 # Define the base directory where you want to start scanning
 BASE_DIR="kernel"
 
-# Function to check if the KernelSU directory is present and remove the folder
-remove_if_kernelsu() {
+# Function to check if the KernelSU directory is present and remove subdirectories
+remove_subdirs_if_kernelsu() {
   local dir="$1"
-  
-  # Check if KernelSU directory exists in the given folder
-  if [ -d "$dir/KernelSU" ]; then
-    echo "Removing $dir because KernelSU directory is present."
-    rm -rf -v "$dir"
+
+  # Check if KernelSU directory exists at any level in the given folder
+  if find "$dir" -type d -name "KernelSU" | grep -q .; then
+    echo "Removing subdirectories of $dir because KernelSU directory is present."
+    find "$dir" -mindepth 1 -maxdepth 1 -type d -exec rm -rf -v {} \;
   fi
 }
 
-# Loop through all subdirectories under kernel/*/*
-for dir in "$BASE_DIR"/*/*; do
+# Loop through all subdirectories under kernel
+for dir in "$BASE_DIR"/*; do
   # Check if the current path is a directory
   if [ -d "$dir" ]; then
-    remove_if_kernelsu "$dir"
+    remove_subdirs_if_kernelsu "$dir"
   fi
 done
+
+echo "Dirty kernel trees with KernelSU residues cleaned. Job complete."

--- a/ci/clean_dirty_kernels.sh
+++ b/ci/clean_dirty_kernels.sh
@@ -1,0 +1,21 @@
+# Define the base directory where you want to start scanning
+BASE_DIR="kernel"
+
+# Function to check if the KernelSU directory is present and remove the folder
+remove_if_kernelsu() {
+  local dir="$1"
+  
+  # Check if KernelSU directory exists in the given folder
+  if [ -d "$dir/KernelSU" ]; then
+    echo "Removing $dir because KernelSU directory is present."
+    rm -rf -v "$dir"
+  fi
+}
+
+# Loop through all subdirectories under kernel/*/*
+for dir in "$BASE_DIR"/*/*; do
+  # Check if the current path is a directory
+  if [ -d "$dir" ]; then
+    remove_if_kernelsu "$dir"
+  fi
+done


### PR DESCRIPTION
This can cause issues to later builds. Example error:

[ 94% 1120/1184] including kernel/xiaomi/vince/KernelSU/userspace/su/jni/Android.mk ... FAILED:
In file included from hardware/xiaomi/aidl/power-libperfmgr/Android.mk:17: In file included from kernel/xiaomi/vince/KernelSU/userspace/su/jni/Android.mk:6: In file included from build/make/core/executable.mk:53: In file included from build/make/core/executable_internal.mk:29: In file included from build/make/core/dynamic_binary.mk:34: In file included from build/make/core/binary.mk:9: build/make/core/base_rules.mk:338: error: kernel/xiaomi/vince/KernelSU/userspace/su/jni: MODULE.TARGET.EXECUTABLES.su already defined by system/extras/su. 11:46:47 ckati failed with: exit status 1
#### failed to build some targets (01:29 (mm:ss)) ####